### PR TITLE
[Hacktoberfest] Migrate docs to jenkinsci repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <java.level>8</java.level>
     </properties>
 
-    <url>https://wiki.jenkins.io/display/JENKINS/Custom+Build+Properties+Plugin</url>
+    <url>https://github.com/jenkinsci/custom-build-properties-plugin</url>
 
     <scm>
         <connection>scm:git:ssh://git@github.com/jenkinsci/custom-build-properties-plugin.git</connection>


### PR DESCRIPTION
This PR migrates the Custom Build Properties documentation from the **plugins-wiki-docs** repo to the **custom-build-properties** repo as part of the Hacktoberfest docs-to-code project. Since the documentation for this plugin was already in the README, all I did was update the pom.xml file with the new URL for the docs.

Please add the **hacktoberfest-accepted** label if you approve this PR. Thank you!

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did