### PR TITLE
Step waitForCustomBuildProperties terminates when aborting a build

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,7 @@ Per default custom build properties are displayed as a key value table. In order
 
 ## License
 [MIT License](http://opensource.org/licenses/MIT)
+
+## Versioning
+
+This plugin uses automatic versioning with a manually controlled prefix.


### PR DESCRIPTION
Dummy PR to release bugfix (see 9f468a05) pushed before switching to new CD with automatic versioning.