### PR TITLE
[JENKINS-68460] Prepare Custom Build Properties for removal of JAXB and Java 11 requirement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,5 +82,10 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>junit</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>jaxb</artifactId>
+            <version>2.3.6-1</version>
+        </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <properties>
         <revision>2</revision>
         <changelist>999999-SNAPSHOT</changelist>
-        <jenkins.version>2.204.1</jenkins.version>
+        <jenkins.version>2.263.1</jenkins.version>
         <java.level>8</java.level>
     </properties>
 
@@ -65,8 +65,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.204.x</artifactId>
-                <version>18</version>
+                <artifactId>bom-2.263.x</artifactId>
+                <version>984.vb5eaac999a7e</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
See [JENKINS-68460](https://issues.jenkins.io/browse/JENKINS-68460). While a better solution would be to rewrite the usage in `CustomBuildPropertiesAction` to avoid the use of `javax.xml.bind.DatatypeConverter` in favor of the Java Platform's built-in `DateTimeFormatter` class for parsing ISO8601 dates, that is a riskier change that I have no easy way of testing. So in this PR I am adding a plugin-to-plugin dependency on JAXB API plugin to preserve the status quo. The path of least resistance is to merge and release this PR so that this plugin continues to work when Jenkins core starts requiring Java 11 in September. Feel free to close this PR and create your own PR implementing the `DateTimeFormatter` if you would prefer to drop the dependency on JAXB entirely. If no action is taken, this functionality will stop working when Jenkins core starts requiring Java 11 at the end of the year. CC @shasait