### PR TITLE
Remove deprecated `java.level` property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,6 @@
         <revision>2</revision>
         <changelist>999999-SNAPSHOT</changelist>
         <jenkins.version>2.263.1</jenkins.version>
-        <java.level>8</java.level>
     </properties>
 
     <url>https://github.com/jenkinsci/custom-build-properties-plugin</url>


### PR DESCRIPTION
The `java.level` property was deprecated in [plugin parent POM 4.40](https://github.com/jenkinsci/plugin-pom/releases/tag/plugin-4.40) and should be removed from this plugin's POM. In the future this warning will be changed to an error and will break the build. See https://github.com/jenkinsci/plugin-pom/pull/522 for details.